### PR TITLE
Updated README.md to exclude Butterknife

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ If your project has ButterKnife installed
 ```
     dependencies {
         compile('com.github.StephaneBg:SimpleNumberPicker:1.0') {
-            exclude group: 'com.jakewharton' module: 'butterknife'
-            exclude group: 'com.jakewharton' module: 'butterknife-compile'
+            exclude group: 'com.jakewharton', module: 'butterknife'
+            exclude group: 'com.jakewharton', module: 'butterknife-compile'
         }
     }
 ```
+This prevents the library from loading its own Butterknife and use your app's Butterknife.
+for complete compatibility, please use Butterknife 8.4.0 and above.'
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,27 @@ A customisable decimal and hexadecimal material picker view for Android.
 ## Download
 Add the JitPack repository in your build.gradle at the end of repositories:
 ```
-	allprojects {
-		repositories {
-			...
-			maven { url "https://jitpack.io" }
-		}
-	}
+    allprojects {
+        repositories {
+            ...
+            maven { url "https://jitpack.io" }
+        }
+    }
 ```
 And add the dependency
 ```
-	dependencies {
-	        compile 'com.github.StephaneBg:SimpleNumberPicker:1.0'
-	}
+    dependencies {
+            compile 'com.github.StephaneBg:SimpleNumberPicker:1.0'
+    }
+```
+If your project has ButterKnife installed
+```
+    dependencies {
+        compile('com.github.StephaneBg:SimpleNumberPicker:1.0') {
+            exclude group: 'com.jakewharton' module: 'butterknife'
+            exclude group: 'com.jakewharton' module: 'butterknife-compile'
+        }
+    }
 ```
 
 ## Usage


### PR DESCRIPTION
I just took the liberty of updating the README.md file.
I just added a snippet that disables the library's own Butterknife and use the project/app Butterknife.

If you might wonder why, I encountered a compile error when the library. And, I found out that Butterknife is the conflict. Its okay if the library's Butterknife and the app's Butterknife is on the same version. But if they're different, then the conflict will arise.

I haven't experienced it but I think this will be also the same with the support libraries, buildTools version the library is using. Needs to be confirmed.

Thanks for the great library! :)

> P.S: Please fix your release build for 1.0 so that the users will be able to use the 1.0 tag instead of master-SNAPSHOT tag.